### PR TITLE
handle quote escaping by JSON.stringify instead manual handling in passEventToBrowser

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,8 +104,8 @@ if(!glob[PROCESS_EVENT]){
 }
 
 function passEventToBrowser(browser: Browser, data: Event, ignoreNotFound: boolean): void {
-    const raw = util.stringifyData(data).replace(/'/g, "\\'");
-    browser.execute(`var process = window["${PROCESS_EVENT}"]; if(process){ process('${raw}'); }else{ ${ignoreNotFound ? '' : `mp.trigger("${PROCESS_EVENT}", '{"ret":1,"id":"${data.id}","err":"${ERR_NOT_FOUND}","env":"cef"}');`} }`);
+    const raw = util.stringifyData(data)
+    browser.execute(`var process = window["${PROCESS_EVENT}"]; if(process){ process(${JSON.stringify(raw)}); }else{ ${ignoreNotFound ? '' : `mp.trigger("${PROCESS_EVENT}", '{"ret":1,"id":"${data.id}","err":"${ERR_NOT_FOUND}","env":"cef"}');`} }`);
 }
 
 function callProcedure(name: string, args: any, info: ProcedureListenerInfo): Promise<any> {


### PR DESCRIPTION
Previous quotes handling would throw an error "unexpected token at .." if you try to pass next data variable as argument to `callBrowser`:
```javascript
const data = "^(([^<>()\\[\\]\\\\.,;:\\s@\"]+(\\.[^<>()\\[\\]\\\\.,;:\\s@\"]+)*)|(\".+\"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$"

rpc.callBrowser(someBrowser, "someName", data) // will throw an error in browser console
```

P.S. this fix works great with strings that contain single quotes (#2)