### PR TITLE
Add default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -333,3 +333,13 @@ export function callBrowser(browser: Browser, name: string, args?: any): Promise
     const id = util.uid();
     return _callBrowser(id, browser, name, args, {});
 }
+
+export default {
+    register,
+    unregister,
+    call,
+    callServer,
+    callClient,
+    callBrowsers,
+    callBrowser
+};


### PR DESCRIPTION
it's just somewhat annoyign to write `import * as rpc from 'rage-rpc';` every time you want to import whole package. You could import only the methods you use, but they by themselves does not exactly describe what they do (e.g. `register()` can mean a lot of things, while rpc.register is much easier to understand)