### PR TITLE
Nolimit

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -120,3 +120,17 @@ export function isBrowserValid(browser: Browser): boolean {
     }catch(e){ return false; }
     return true;
 }
+
+export function chunkSubstr(str: string, size: number): Array<String> {
+    const numChunks = Math.ceil(str.length / size);
+    const chunks = new Array(numChunks);
+
+    let index = 0;
+    for (let i = 0; i < numChunks; i += 1) {
+        chunks[i] = str.substr(index, size);
+
+        index += size;
+    }
+  
+    return chunks;
+}


### PR DESCRIPTION
By default ragemp limited to 2^15 symbols for sending through events. This PR removes this limitation by splitting large data to smaller parts.