### PR TITLE
Fix call procedure rejection with no args provided

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,13 +55,13 @@ if(!glob[PROCESS_EVENT]){
             }
             if(ret){
                 const promise = callProcedure(data.name, data.args, info);
-                if(!data.noRet) promise.then(res => ret({ ...part, res })).catch(err => ret({ ...part, err }));
+                if(!data.noRet) promise.then(res => ret({ ...part, res })).catch(err => ret({ ...part, err: err ? err : null }));
             }
         }else if(data.ret){ // a previously called remote procedure has returned
             const info = glob.__rpcPending[data.id];
             if(environment === "server" && info.player !== player) return;
             if(info){
-                info.resolve(data.err ? util.promiseReject(data.err) : util.promiseResolve(data.res));
+                info.resolve(data.hasOwnProperty('err') ? util.promiseReject(data.err) : util.promiseResolve(data.res));
                 delete glob.__rpcPending[data.id];
             }
         }


### PR DESCRIPTION
This PR fixes wrong `resolve` behaviour when no reason provided into promise reject.

## Code to reproduce the issue
Client:
```js
rpc.register('test', (data, info) => {
  return new Promise((resolve, reject) => {
    reject();
  });
});
```

Server:
```js
rpc.callClient(player, 'test').then(() => {
  console.log('resolve');
}).catch(() => {
  console.log('reject');
});
```

Results:
```
resolve
```